### PR TITLE
BACKPORT: PCI-4669 Improve EC2 describe_security_groups performance:

### DIFF
--- a/nova/api/ec2/cloud.py
+++ b/nova/api/ec2/cloud.py
@@ -490,7 +490,7 @@ class CloudController(object):
             r['groups'] = []
             r['ipRanges'] = []
             if rule.group_id:
-                source_group = db.security_group_get(context, rule.group_id)
+                source_group = rule.grantee_group
                 r['groups'] += [{'groupName': source_group.name,
                                  'userId': source_group.project_id}]
                 if rule.protocol:

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -3532,7 +3532,7 @@ def _security_group_get_query(context, session=None, read_deleted=None,
     query = model_query(context, models.SecurityGroup, session=session,
             read_deleted=read_deleted, project_only=project_only)
     if join_rules:
-        query = query.options(joinedload_all('rules'))
+        query = query.options(joinedload_all('rules.grantee_group'))
     return query
 
 
@@ -3589,7 +3589,7 @@ def security_group_get_by_name(context, project_id, group_name,
             filter_by(name=group_name)
 
     if columns_to_join is None:
-        columns_to_join = ['instances', 'rules']
+        columns_to_join = ['instances', 'rules.grantee_group']
 
     for column in columns_to_join:
         query = query.options(joinedload_all(column))


### PR DESCRIPTION
*Description*

The current implementation of EC2 describe_secuity_groups makes one
query per grantee group rule in _format_security_group. This will
dramatically slow down response time if users make strong use of
grantee group rules.

This patch uses just one DB query to get security groups with joined
grantee_group rules to improve the performance.

*Perf tets*

Show us 70x speed up.