### PR TITLE
libvirt: avoid changing UUID when redefining nwfilters

### DIFF
--- a/nova/virt/libvirt/firewall.py
+++ b/nova/virt/libvirt/firewall.py
@@ -17,7 +17,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import uuid
 
+from lxml import etree
 from eventlet import tpool
 
 from nova import flags
@@ -57,14 +59,13 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
         return self._libvirt_get_connection()
     _conn = property(_get_connection)
 
-    @staticmethod
-    def nova_dhcp_filter():
+    def nova_dhcp_filter(self):
         """The standard allow-dhcp-server filter is an <ip> one, so it uses
            ebtables to allow traffic through. Without a corresponding rule in
            iptables, it'll get blocked anyway."""
-
+        uuid = self._get_filter_uuid('nova-allow-dhcp-server')
         return '''<filter name='nova-allow-dhcp-server' chain='ipv4'>
-                    <uuid>891e4787-e5c0-d59b-cbd6-41bc3c6b36fc</uuid>
+                    <uuid>%s</uuid>
                     <rule action='accept' direction='out'
                           priority='100'>
                       <udp srcipaddr='0.0.0.0'
@@ -78,7 +79,7 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
                            srcportstart='67'
                            dstportstart='68'/>
                     </rule>
-                  </filter>'''
+                  </filter>''' % uuid
 
     def setup_basic_filtering(self, instance, network_info):
         """Set up basic filtering (MAC, IP, and ARP spoofing protection)"""
@@ -133,15 +134,31 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
                                                     'no-arp-spoofing']))
         self._define_filter(self._filter_container('nova-vpn',
                                                    ['allow-dhcp-server']))
-        self._define_filter(self.nova_dhcp_filter)
+        self._define_filter(self.nova_dhcp_filter())
 
         self.static_filters_configured = True
 
     def _filter_container(self, name, filters):
-        xml = '''<filter name='%s' chain='root'>%s</filter>''' % (
-                 name,
+        uuid = self._get_filter_uuid(name)
+        xml = '''<filter name='%s' chain='root'>
+                   <uuid>%s</uuid>
+                   %s
+                 </filter>''' % (name, uuid,
                  ''.join(["<filterref filter='%s'/>" % (f,) for f in filters]))
         return xml
+
+    def _get_filter_uuid(self, name):
+        try:
+            flt = self._conn.nwfilterLookupByName(name)
+            xml = flt.XMLDesc(0)
+            doc = etree.fromstring(xml)
+            u = doc.find("./uuid").text
+        except Exception as e:
+            LOG.debug("Cannot find UUID for filter '%s': '%s'" % (name, e))
+            u = uuid.uuid4().hex
+
+        LOG.debug("UUID for filter '%s' is '%s'" % (name, u))
+        return u
 
     def _define_filter(self, xml):
         if callable(xml):


### PR DESCRIPTION
libvirt >= 1.2.7 enforces that when you re-define a network
filter you can't change the UUID. ie name + uuid must match.
Since Nova was not including any UUID in the XML it sent, it
would always get a random UUID generated, which would cause
failures when re-defining an existing filter. The result
was that Nova would fail to start up and fail to migrate
if there was an existing guest running. The fix is to query
libvirt to see if the nwfilter already exists, and extract
the UUID from its XML and use that when re-defining it.

(cherry picked from commit 2418a9dce86280fbf269f68f7d7c9b739f662ef1)

Cherry-pick addapted to Folsom code --BranoZ