### PR TITLE
Fix resizing in imagebackend.cache()

### DIFF
--- a/nova/virt/libvirt/imagebackend.py
+++ b/nova/virt/libvirt/imagebackend.py
@@ -251,7 +251,9 @@ class Image(object):
                               *args, **kwargs)
 
         if size:
-            if size > self.get_disk_size(base):
+            # create_image() only creates the base image if needed, so
+            # we cannot rely on it to exist here
+            if os.path.exists(base) and size > self.get_disk_size(base):
                 self.resize_image(size)
 
             if (self.preallocate and self._can_fallocate() and


### PR DESCRIPTION
The Raw and Lvm backends do not create a 'base image' (the file in the
image cache) when creating an ephemeral or swap disk. However, cache()
expects it to exist when checking if a resize is required.

This change ignores the resize check if the backing file doesn't exist.
This happens to be ok, because ephemeral and swap disks are always
created with the correct target size anyway, and therefore never need
to be resized.

NOTE(mriedem): There is a slight change in the commit message and
test since the Raw image backend was renamed to Flat in Newton. Since
Flat didn't exist in Mitaka it's better to use Raw here.

Closes-Bug: 1608934
Co-Authored-By: Matthew Booth <mbooth@redhat.com>
Change-Id: I46b5658efafe558dd6b28c9910fb8fde830adec0
(cherry picked from commit d0775c50d0c2bd50a62ccd49ea7063948af6c3b3)