### PR TITLE
PAAS-12718: Replace deprecated DataPlane option with IOthreads, disable config-wce and use io='native' in volume driver

### DIFF
--- a/nova/tests/unit/virt/libvirt/test_config.py
+++ b/nova/tests/unit/virt/libvirt/test_config.py
@@ -1907,7 +1907,7 @@ class LibvirtConfigGuestTest(LibvirtConfigBaseTest):
               </devices>
             </domain>""")
 
-    def test_config_kvm_dataplane(self):
+    def test_config_kvm_iothreads(self):
         obj = config.LibvirtConfigGuest()
         obj.virt_type = "kvm"
         obj.memory = 100 * units.Mi
@@ -1921,7 +1921,6 @@ class LibvirtConfigGuestTest(LibvirtConfigBaseTest):
         obj.os_type = "linux"
         obj.os_boot_dev = ["hd", "cdrom", "fd"]
         obj.os_smbios = config.LibvirtConfigGuestSMBIOS()
-        obj.dataplane = True
 
         obj.cputune = config.LibvirtConfigGuestCPUTune()
         obj.cputune.shares = 100
@@ -1955,6 +1954,7 @@ class LibvirtConfigGuestTest(LibvirtConfigBaseTest):
                    <entry name="version">1.0.0</entry>
                  </system>
               </sysinfo>
+              <iothreads>1</iothreads>
               <os>
                 <type>linux</type>
                 <boot dev="hd"/>
@@ -1968,7 +1968,7 @@ class LibvirtConfigGuestTest(LibvirtConfigBaseTest):
                 <period>25000</period>
               </cputune>
               <devices>
-                <disk type="file" device="disk">
+                <disk type="file" device="disk" iothread="1">
                   <source file="/tmp/img"/>
                   <target bus="virtio" dev="/dev/vda"/>
                 </disk>
@@ -1976,9 +1976,7 @@ class LibvirtConfigGuestTest(LibvirtConfigBaseTest):
               <qemu:commandline xmlns:qemu=\
 "http://libvirt.org/schemas/domain/qemu/1.0">
                   <qemu:arg value="-global"/>
-                  <qemu:arg value="virtio-blk-pci.scsi=off"/>
-                  <qemu:arg value="-global"/>
-                  <qemu:arg value="virtio-blk-pci.x-data-plane=on"/>
+                  <qemu:arg value="virtio-blk-pci.config-wce=off"/>
                </qemu:commandline>
             </domain>""")
 

--- a/nova/virt/libvirt/guest.py
+++ b/nova/virt/libvirt/guest.py
@@ -477,6 +477,9 @@ class Guest(object):
         """
         self._domain.suspend()
 
+    def get_iothreads(self):
+        ret = self._domain.ioThreadInfo()
+        return len(ret)
 
 class BlockDevice(object):
     """Wrapper around block device API"""

--- a/nova/virt/libvirt/volume/volume.py
+++ b/nova/virt/libvirt/volume/volume.py
@@ -57,6 +57,7 @@ class LibvirtBaseVolumeDriver(object):
             self.is_block_dev
         )
 
+        conf.iothread = 2
         conf.source_device = disk_info['type']
         conf.driver_format = "raw"
         conf.driver_cache = "none"
@@ -146,6 +147,7 @@ class LibvirtVolumeDriver(LibvirtBaseVolumeDriver):
                      self).get_config(connection_info, disk_info)
         conf.source_type = "block"
         conf.source_path = connection_info['data']['device_path']
+        conf.driver_io = "native"
         return conf
 
 

--- a/openstack-nova.spec
+++ b/openstack-nova.spec
@@ -9,7 +9,7 @@ Name:             openstack-nova
 # https://review.openstack.org/#/q/I6a35fa0dda798fad93b804d00a46af80f08d475c,n,z
 Epoch:            1
 Version:          13.1.2
-Release:          4%{?gdc_version}%{?dist}
+Release:          5%{?gdc_version}%{?dist}
 Summary:          OpenStack Compute (nova)
 
 License:          ASL 2.0
@@ -824,6 +824,9 @@ exit 0
 %endif
 
 %changelog
+* Fri Jan 19 2018 Jaroslav Pulchart <jaroslav.pulchart@gooddata.com> 1:13.1.2-5.gdc
+- PAAS-12718 Replace deprecated DataPlane options with IOthreads, disable config-wce and use io='native' in volume driver
+
 * Fri Jan 5 2018 Jaroslav Pulchart <jaroslav.pulchart@gooddata.com> 1:13.1.2-4.gdc
 - PAAS-12889 Allow spreading over NUMA nodes if flavor property 'hw:numa_spreading=true' is set
 


### PR DESCRIPTION
* Replace deprecated DataPlane option with IOthreads. The setup is backward compatible with older (running) Instances deployed with dataplane option without iothreads.  
* Disable config-wce
* Add missing io='native' into volume driver.
